### PR TITLE
Adds preprocessing option for removing redundant edges

### DIFF
--- a/spp/bezier.py
+++ b/spp/bezier.py
@@ -36,6 +36,7 @@ from pydrake.trajectories import (
 )
 
 from spp.base import BaseSPP
+from spp.preprocessing import removeRedundancies
 
 class BezierSPP(BaseSPP):
     def __init__(self, regions, order, continuity, edges=None, hdot_min=1e-6):
@@ -224,7 +225,7 @@ class BezierSPP(BaseSPP):
 
 
     def SolvePath(self, source, target, rounding=False, verbose=False, edges=None, velocity=None,
-                  zero_deriv_boundary=None):
+                  zero_deriv_boundary=None, preprocessing=False):
         assert len(source) == self.dimension
         assert len(target) == self.dimension
 
@@ -303,6 +304,9 @@ class BezierSPP(BaseSPP):
 
         if not source_connected or not target_connected:
             print("Source connected:", source_connected, "Target connected:", target_connected)
+
+        if preprocessing:
+            removeRedundancies(self.spp, start, goal)
 
         active_edges, result, hard_result = self.solveSPP(start, goal, rounding)
 

--- a/spp/bezier.py
+++ b/spp/bezier.py
@@ -301,12 +301,13 @@ class BezierSPP(BaseSPP):
             for d_con in self.deriv_constraints:
                 edge.AddConstraint(Binding[Constraint](d_con, u.x()))
 
-
-        if not source_connected or not target_connected:
-            print("Source connected:", source_connected, "Target connected:", target_connected)
+        if not source_connected:
+            raise ValueError('Source vertex is not connected.')
+        if not target_connected:
+            raise ValueError('Target vertex is not connected.')
 
         if preprocessing:
-            removeRedundancies(self.spp, start, goal)
+            removeRedundancies(self.spp, start, goal, verbose=verbose)
 
         active_edges, result, hard_result = self.solveSPP(start, goal, rounding)
 

--- a/spp/bezier.py
+++ b/spp/bezier.py
@@ -36,7 +36,6 @@ from pydrake.trajectories import (
 )
 
 from spp.base import BaseSPP
-from spp.preprocessing import removeRedundancies
 
 class BezierSPP(BaseSPP):
     def __init__(self, regions, order, continuity, edges=None, hdot_min=1e-6):
@@ -306,26 +305,8 @@ class BezierSPP(BaseSPP):
         if not target_connected:
             raise ValueError('Target vertex is not connected.')
 
-        if preprocessing:
-            removeRedundancies(self.spp, start, goal, verbose=verbose)
-
-        active_edges, result, hard_result = self.solveSPP(start, goal, rounding)
-
-        if verbose:
-            print("Solution\t",
-                  "Success:", result.get_solution_result(),
-                  "Cost:", result.get_optimal_cost(),
-                  "Solver time:", result.get_solver_details().optimizer_time)
-            if rounding and hard_result is not None:
-                print("Rounded Solutions:")
-                for r in hard_result:
-                    if r is None:
-                        print("\t\tNo path to solve")
-                        continue
-                    print("\t\t",
-                        "Success:", r.get_solution_result(),
-                        "Cost:", r.get_optimal_cost(),
-                        "Solver time:", r.get_solver_details().optimizer_time)
+        active_edges, result, hard_result = self.solveSPP(
+            start, goal, rounding, preprocessing, verbose)
 
         if active_edges is None:
             self.ResetGraph([start, goal])

--- a/spp/linear.py
+++ b/spp/linear.py
@@ -14,7 +14,6 @@ from pydrake.solvers.mathematicalprogram import (
 )
 
 from spp.base import BaseSPP
-from spp.preprocessing import removeRedundancies
 
 class LinearSPP(BaseSPP):
     def __init__(self, regions, edges=None):
@@ -79,26 +78,8 @@ class LinearSPP(BaseSPP):
         if not target_connected:
             raise ValueError('Target vertex is not connected.')
 
-        if preprocessing:
-            removeRedundancies(self.spp, start, goal, verbose=verbose)
-
-        active_edges, result, hard_result = self.solveSPP(start, goal, rounding)
-
-        if verbose:
-            print("Solution\t",
-                  "Success:", result.get_solution_result(),
-                  "Cost:", result.get_optimal_cost(),
-                  "Solver time:", result.get_solver_details().optimizer_time)
-            if rounding and hard_result is not None:
-                print("Rounded Solutions:")
-                for r in hard_result:
-                    if r is None:
-                        print("\t\tNo path to solve")
-                        continue
-                    print("\t\t",
-                        "Success:", r.get_solution_result(),
-                        "Cost:", r.get_optimal_cost(),
-                        "Solver time:", r.get_solver_details().optimizer_time)
+        active_edges, result, hard_result = self.solveSPP(
+            start, goal, rounding, preprocessing, verbose)
 
         if active_edges is None:
             self.ResetGraph([start, goal])

--- a/spp/linear.py
+++ b/spp/linear.py
@@ -14,6 +14,7 @@ from pydrake.solvers.mathematicalprogram import (
 )
 
 from spp.base import BaseSPP
+from spp.preprocessing import removeRedundancies
 
 class LinearSPP(BaseSPP):
     def __init__(self, regions, edges=None):
@@ -44,7 +45,7 @@ class LinearSPP(BaseSPP):
                                  u.set().b()),
                 v.x()))
 
-    def SolvePath(self, source, target, rounding=False, verbose=False, edges=None):
+    def SolvePath(self, source, target, rounding=False, verbose=False, edges=None, preprocessing=False):
         assert len(source) == self.dimension
         assert len(target) == self.dimension
 
@@ -75,6 +76,9 @@ class LinearSPP(BaseSPP):
 
         if not source_connected or not target_connected:
             print("Source connected:", source_connected, "Target connected:", target_connected)
+
+        if preprocessing:
+            removeRedundancies(self.spp, start, goal)
 
         active_edges, result, hard_result = self.solveSPP(start, goal, rounding)
 

--- a/spp/linear.py
+++ b/spp/linear.py
@@ -74,11 +74,13 @@ class LinearSPP(BaseSPP):
             edge.AddCost(Binding[Cost](
                 self.edge_cost, np.append(u.x(), goal.x())))
 
-        if not source_connected or not target_connected:
-            print("Source connected:", source_connected, "Target connected:", target_connected)
+        if not source_connected:
+            raise ValueError('Source vertex is not connected.')
+        if not target_connected:
+            raise ValueError('Target vertex is not connected.')
 
         if preprocessing:
-            removeRedundancies(self.spp, start, goal)
+            removeRedundancies(self.spp, start, goal, verbose=verbose)
 
         active_edges, result, hard_result = self.solveSPP(start, goal, rounding)
 

--- a/spp/preprocessing.py
+++ b/spp/preprocessing.py
@@ -1,0 +1,86 @@
+import numpy as np
+from pydrake.all import MathematicalProgram, Solve, ge
+from copy import copy
+from numbers import Number
+
+def removeRedundancies(gcs, s, t, tol=1e-4, verbose=False):
+
+    if verbose:
+        print('Vertices before preprocessing:', len(gcs.Vertices()))
+        print('Edges before preprocessing:', len(gcs.Edges()))
+    
+    for e in copy(gcs.Edges()):
+
+        prog = MathematicalProgram()
+        
+        # Flow variables from s to u.
+        nE = len(gcs.Edges())
+        if s != e.u():
+            f = prog.NewContinuousVariables(nE, 'f')
+            fs = prog.NewContinuousVariables(1)[0]
+            prog.AddLinearConstraint(ge(f, 0))
+            prog.AddLinearConstraint(fs >= 0)
+        else:
+            f = np.zeros(nE)
+            fs = 1
+        prog.AddLinearCost(- fs)
+
+        # Flow variables from v to t.
+        if t != e.v():
+            g = prog.NewContinuousVariables(nE, 'g')
+            gv = prog.NewContinuousVariables(1)[0]
+            prog.AddLinearConstraint(ge(g, 0))
+            prog.AddLinearConstraint(gv >= 0)
+        else:
+            g = np.zeros(nE)
+            gv = 1
+        prog.AddLinearCost(- gv)
+        
+        for w in gcs.Vertices():
+            
+            # Conservation of flow for f.
+            Ein = [k for k, e in enumerate(gcs.Edges()) if e.v() == w]
+            Eout = [k for k, e in enumerate(gcs.Edges()) if e.u() == w]
+            fin = sum(f[k] for k in Ein)
+            fout = sum(f[k] for k in Eout)
+            diff_f = fout - fin
+            if w == s:
+                diff_f -= fs
+            if w == e.u():
+                diff_f += fs
+            if not isinstance(diff_f, Number):
+                prog.AddLinearConstraint(diff_f == 0)
+            
+            # Conservation of flow for g.
+            gin = sum(g[k] for k in Ein)
+            gout = sum(g[k] for k in Eout)
+            diff_g = gout - gin
+            if w == e.v():
+                diff_g -= gv
+            if w == t:
+                diff_g += gv
+            if not isinstance(diff_g, Number):
+                prog.AddLinearConstraint(diff_g == 0)
+            
+            # Degree constraint for cumulative f + g.
+            if w == s or w == e.v():
+                fg_w = fout + gout
+            else:
+                fg_w = fin + gin
+            if not isinstance(fg_w, Number):
+                prog.AddLinearConstraint(fg_w <= 1)
+            
+        # Check if edge e = (u,v) is redundant. 
+        result = Solve(prog)
+        if not result.is_success() or result.get_optimal_cost() > - 2 + tol:
+            gcs.RemoveEdge(e)
+            
+    # Remove isolated vertices.
+    for w in copy(gcs.Vertices()):
+        E = [e for e in gcs.Edges() if e.u() == w or e.v() == w]
+        if len(E) == 0:
+            gcs.RemoveVertex(w)
+
+    if verbose:
+        print('Vertices after preprocessing:', len(gcs.Vertices()))
+        print('Edges after preprocessing:', len(gcs.Edges()))

--- a/spp/preprocessing.py
+++ b/spp/preprocessing.py
@@ -1,7 +1,11 @@
 import numpy as np
 from pydrake.all import MathematicalProgram, Solve
+from time import time
 
 def removeRedundancies(gcs, s, t, tol=1e-4, verbose=False):
+
+    # Store time necessary to run the function and to solve the optimizations.
+    preprocessing_times = {'total': time(), 'linear_programs': 0}
 
     if verbose:
         print('Vertices before preprocessing:', len(gcs.Vertices()))
@@ -98,6 +102,7 @@ def removeRedundancies(gcs, s, t, tol=1e-4, verbose=False):
 
         # Check if edge e = (u,v) is redundant. 
         result = Solve(prog)
+        preprocessing_times['linear_programs'] += result.get_solver_details().optimizer_time
         if not result.is_success():
             redundant_edges.append(e)
 
@@ -119,6 +124,11 @@ def removeRedundancies(gcs, s, t, tol=1e-4, verbose=False):
         gcs.RemoveEdge(e)
     removeIsolatedVertices()
 
+    preprocessing_times['total'] = time() - preprocessing_times['total']
     if verbose:
         print('Vertices after preprocessing:', len(gcs.Vertices()))
         print('Edges after preprocessing:', len(gcs.Edges()))
+        print('Total time for preprocessing:', preprocessing_times['total'])
+        print('Time spent solving linear programs:', preprocessing_times['linear_programs'])
+
+    return preprocessing_times


### PR DESCRIPTION
Adds preprocessing as an option for LinearSPP and BezierSPP. I tried it on the 2d examples and it seems to work fine.

The current preprocessing runs before the solve, when the source and the target are given. It iterates through the edges, and for each edge solves a max-flow-like linear program to see if the edge can be along an s-t path. The check is only a sufficient condition, i.e. it might be that an edge cannot be along an s-t path but the current check does not recognize that. However, I believe that these corner cases should be very rare. (A necessary and sufficient preprocessing is NP-hard, since it is equivalent to the 2 directed disjoint path problem: https://web.cs.elte.hu/egres/tr/egres-16-13.pdf.)

I imagine this preprocessing to be useful when the problems are high-dimensional but the graph is small (i.e. the prm_vs_spp and the bimanual). In the maze example (low-dimensional but huge graph) the processing takes a very long time and it isn't worth it.










