### PR TITLE
Reorganizes rounding methods that are based on depth first

### DIFF
--- a/spp/rounding.py
+++ b/spp/rounding.py
@@ -42,7 +42,6 @@ def randomEdgeSelector(candidate_edges, flows):
     return np.random.choice(candidate_edges, p=probabilities)
 
 def greedyForwardPathSearch(gcs, result, source, target, flow_tol=1e-5, **kwargs):
-    print('greedyForwardPathSearch')
 
     outgoing_edges = outgoingEdges(gcs)
     flows = optimalFlows(gcs, result)
@@ -58,7 +57,6 @@ def greedyForwardPathSearch(gcs, result, source, target, flow_tol=1e-5, **kwargs
     return [depthFirst(source, target, candidateEdges, selector)]
 
 def randomForwardPathSearch(gcs, result, source, target, num_paths=10, seed=None, flow_tol=1e-5, **kwargs):
-    print('randomForwardPathSearch')
 
     if seed is not None:
         np.random.seed(seed)
@@ -77,7 +75,6 @@ def randomForwardPathSearch(gcs, result, source, target, num_paths=10, seed=None
     return [depthFirst(source, target, candidateEdges, selector) for _ in range(num_paths)]
 
 def greedyBackwardPathSearch(gcs, result, source, target, flow_tol=1e-5, **kwargs):
-    print('greedyBackwardPathSearch')
 
     incoming_edges = incomingEdges(gcs)
     flows = optimalFlows(gcs, result)
@@ -93,7 +90,6 @@ def greedyBackwardPathSearch(gcs, result, source, target, flow_tol=1e-5, **kwarg
     return [depthFirst(target, source, candidateEdges, selector)[::-1]]
 
 def randomBackwardPathSearch(gcs, result, source, target, num_paths=10, seed=None, flow_tol=1e-5, **kwargs):
-    print('randomBackwardPathSearch')
 
     if seed is not None:
         np.random.seed(seed)
@@ -115,7 +111,6 @@ def MipPathExtraction(gcs, result, source, target, **kwargs):
     return greedyForwardPathSearch(gcs, result, source, target)
 
 def averageVertexPositionSpp(gcs, result, source, target, edge_cost_dict=None, flow_min=1e-3, **kwargs):
-    print('averageVertexPositionSpp')
 
     G = nx.DiGraph()
     G.add_nodes_from(gcs.Vertices())

--- a/uav_generated_rooms.ipynb
+++ b/uav_generated_rooms.ipynb
@@ -84,7 +84,7 @@
     "        relax_spp.setPaperSolverOptions()\n",
     "        relax_spp.setSolver(MosekSolver())\n",
     "        relax_spp.addAccelerationRegularization(1e-3, 1e-3)\n",
-    "        relax_spp.setRoundingStrategy(randomPathSearch)\n",
+    "        relax_spp.setRoundingStrategy(randomForwardPathSearch)\n",
     "    \n",
     "        mip_spp = BezierSPP(regions, order, continuity, hdot_min=1e-3)\n",
     "        mip_spp.addTimeCost(weights[\"time\"])\n",
@@ -93,7 +93,7 @@
     "        mip_spp.setPaperSolverOptions()\n",
     "        mip_spp.setSolver(MosekSolver())\n",
     "        mip_spp.addAccelerationRegularization(1e-3, 1e-3)\n",
-    "        mip_spp.setRoundingStrategy(randomPathSearch)\n",
+    "        mip_spp.setRoundingStrategy(randomForwardPathSearch)\n",
     "    \n",
     "        setup_time = time.time() - start_setup\n",
     "        \n",
@@ -449,7 +449,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I wrote a function that has the skeleton of a depth first + backtracking algorithm, so that all the greedy and the randomized rounding methods can use the same base function to work.

Since I coded the random search both in the forward and the backward directions, I renamed `randomPathSearch` as `randomForwardPathSearch`. I fixed this in the UAV example, not sure if it `randomPathSearch` appears somewhere else.